### PR TITLE
Add driver logs pulling

### DIFF
--- a/airflow_home/plugins/airflow_livy/batch.py
+++ b/airflow_home/plugins/airflow_livy/batch.py
@@ -16,10 +16,10 @@ https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceMana
 
 import json
 import logging
-from json import JSONDecodeError
-from codecs import encode, decode
-from numbers import Number
+from codecs import decode
 from html.parser import HTMLParser
+from json import JSONDecodeError
+from numbers import Number
 
 import requests
 from airflow.exceptions import AirflowBadRequest, AirflowException
@@ -123,11 +123,12 @@ class LivyBatchSensor(BaseSensorOperator):
         raise AirflowException(f"Batch {self.batch_id} failed with state '{state}'")
 
     def spill_batch_driver_logs(self):
-        '''
+        """
         The function is using Livy API to get the information about the driver process logs URL and then uses it to pull
         stdout/stderr text logs from driver. Works for YARN-based Spark clusters.
         :return: none
-        '''
+        """
+
         class DriverLogsParser(HTMLParser):
             def __init__(self):
                 self.is_pre = False
@@ -135,7 +136,7 @@ class LivyBatchSensor(BaseSensorOperator):
                 super().__init__()
 
             def handle_starttag(self, tag, attrs):
-                if tag == 'pre':
+                if tag == "pre":
                     self.is_pre = True
 
             def handle_endtag(self, tag):
@@ -151,13 +152,19 @@ class LivyBatchSensor(BaseSensorOperator):
         try:
             # This is entire HTML document with the stdout content between <pre>...</pre> tags.
             stdout_html = requests.get(f"{self.driver_log_url}/stdout/?start=0")
-            html_string = decode(stdout_html.content, 'utf-8')
+            html_string = decode(stdout_html.content, "utf-8")
             parser = DriverLogsParser()
             parser.feed(html_string)
             stdout = parser.text
             logging.info(f"Driver stdout:\n{stdout}\nEnd of Driver stdout.")
 
-        except (JSONDecodeError, LookupError, TypeError, RuntimeError, ConnectionError) as ex:
+        except (
+            JSONDecodeError,
+            LookupError,
+            TypeError,
+            RuntimeError,
+            ConnectionError,
+        ) as ex:
             logging.error(f"Error while pulling Driver logs: {ex}")
 
 

--- a/airflow_home/plugins/airflow_livy/batch.py
+++ b/airflow_home/plugins/airflow_livy/batch.py
@@ -139,20 +139,19 @@ class LivyBatchSensor(BaseSensorOperator):
             return False
         if state == "success":
             logging.info(f"Batch {self.batch_id} has finished successfully!")
-            if self.spill_driver_logs and self.driver_log_url:
-                self.spill_batch_driver_logs()
-            return True
-        if self.spill_driver_logs and self.driver_log_url:
             self.spill_batch_driver_logs()
+            return True
+        self.spill_batch_driver_logs()
         raise AirflowException(f"Batch {self.batch_id} failed with state '{state}'")
 
     def spill_batch_driver_logs(self):
         """
-        The function is using Livy API to get the information about the driver process
-        logs URL and then uses it to pull stdout/stderr text logs from driver.
-        Works for YARN-based Spark clusters.
+        Get the information about the driver process logs URL and then uses it to pull
+        stdout/stderr text logs from driver. Works for YARN-based Spark clusters.
         :return: none
         """
+        if not self.spill_driver_logs or not self.driver_log_url:
+            return
 
         try:
             # This is entire HTML document with the stdout content between

--- a/airflow_home/plugins/airflow_livy/batch.py
+++ b/airflow_home/plugins/airflow_livy/batch.py
@@ -124,8 +124,9 @@ class LivyBatchSensor(BaseSensorOperator):
 
     def spill_batch_driver_logs(self):
         """
-        The function is using Livy API to get the information about the driver process logs URL and then uses it to pull
-        stdout/stderr text logs from driver. Works for YARN-based Spark clusters.
+        The function is using Livy API to get the information about the driver process
+        logs URL and then uses it to pull stdout/stderr text logs from driver.
+        Works for YARN-based Spark clusters.
         :return: none
         """
 
@@ -150,7 +151,8 @@ class LivyBatchSensor(BaseSensorOperator):
                 raise RuntimeError(f"Error while parsing HTML document: {message}")
 
         try:
-            # This is entire HTML document with the stdout content between <pre>...</pre> tags.
+            # This is entire HTML document with the stdout content between
+            # <pre>...</pre> tags.
             stdout_html = requests.get(f"{self.driver_log_url}/stdout/?start=0")
             html_string = decode(stdout_html.content, "utf-8")
             parser = DriverLogsParser()

--- a/airflow_home/plugins/airflow_livy/batch.py
+++ b/airflow_home/plugins/airflow_livy/batch.py
@@ -118,7 +118,7 @@ class LivyBatchSensor(BaseSensorOperator):
         if self.spill_driver_logs and not self.driver_log_url:
             if batch_status["appInfo"]["driverLogUrl"]:
                 self.driver_log_url = batch_status["appInfo"]["driverLogUrl"]
-                logging.debug(f"Driver log URL: {self.driver_log_url}"
+                logging.debug(f"Driver log URL: {self.driver_log_url}")
 
     def poke(self, context):
         logging.info(f"Getting batch {self.batch_id} status...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 apache-airflow==2.0.2
+requests==2.26.0


### PR DESCRIPTION
We'd like to be able to pull driver logs for our Spark apps directly to Airflow. This PR enables that in a non-breaking way (it's disabled by default).